### PR TITLE
Deploy script and other helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+serve :
+	bundle exec jekyll serve --watch
+
+build :
+	bundle exec jekyll build
+
+clean :
+	rm -rf _site/*
+
+deploy : clean build
+	@echo "Deploying to server ..."
+	rsync --checksum --delete -avz _site/* earlyamerican:/websites/earlyamer/www/
+	
+.PHONY: serve build clean deploy
+


### PR DESCRIPTION
@kalbers: Is this way of doing things okay with you? You would run `make deploy` to deploy to the server, as long as you have ssh configured the way we did earlier. There are also other targets to, e.g., preview the site.